### PR TITLE
JupyterLab 2

### DIFF
--- a/lib/directory.nix
+++ b/lib/directory.nix
@@ -15,17 +15,50 @@
     fi
   '';
 
+  # Creates a JUPYTERLAB_DIR with the given extensions.
+  # This operation is impure, so it requires `--option sandbox false`.
+  #
+  # The `extensions` list elements can be “the name of a valid JupyterLab
+  # extension npm package on npm,” or “can be a local directory containing
+  # the extension, a gzipped tarball, or a URL to a gzipped tarball.”
+  # See
+  # https://jupyterlab.readthedocs.io/en/stable/user/extensions.html#installing-extensions
   mkDirectoryWith = { extensions }:
-    # Creates a JUPYTERLAB_DIR with the given extensions.
-    # This operation is impure
+    let extStr = pkgs.lib.concatStringsSep " " extensions; in
+
     pkgs.stdenv.mkDerivation {
       name = "jupyterlab-extended";
       phases = "installPhase";
       buildInputs = with pkgs; [ python3Packages.jupyterlab nodejs  ];
       installPhase = ''
         export HOME=$TMP
-        jupyter labextension install ${pkgs.lib.concatStringsSep " " extensions} --app-dir=$out
-        rm -rf $out/staging/node_modules
+        mkdir -p appdir/staging
+        cp ${jupyter}/lib/python3.[7-9]/site-packages/jupyterlab/staging/yarn.lock appdir/staging
+        chmod +w appdir/staging/yarn.lock
+        jupyter labextension install ${extStr} --app-dir=appdir --debug
+        rm -rf appdir/staging/node_modules
+        mkdir -p $out
+        cp -r appdir/* $out
       '';
     };
+
+  # https://jupyterlab.readthedocs.io/en/stable/user/extensions.html#jupyterlab-build-process
+  # From a jupyter labextension source directory, run the `npm run build`
+  # step. Produces an output which can be passed to
+  # `jupyter labextension install`, which means the output can be passed
+  # as one of the `extensions` arguments to `mkDirectoryWith`.
+  mkBuildExtension = srcPath: pkgs.stdenv.mkDerivation {
+    name = "labextension-source";
+    src = srcPath;
+    buildInputs = [ pkgs.nodejs ];
+    buildPhase = ''
+      export HOME=$TMP
+      npm install
+      npm run build
+      '';
+    installPhase = ''
+      mkdir -p $out/
+      cp -r * $out/
+      '';
+  };
 }

--- a/overlays/haskell-overlay.nix
+++ b/overlays/haskell-overlay.nix
@@ -21,7 +21,7 @@ in {
   ];
   ihaskellPackages = (mkStackPkgSet {
     stack-pkgs = {
-      resolver = "lts-14.13";
+      resolver = "lts-14.27";
       extras = hackage: { };
     };
     pkg-def-extras = self.ihaskell-pkg-def-extras;

--- a/python/jsonschema.nix
+++ b/python/jsonschema.nix
@@ -7,12 +7,13 @@
 }:
 
 buildPythonPackage rec {
+  # https://pypi.org/project/jsonschema/#history
   pname = "jsonschema";
-  version = "3.1.1";
+  version = "3.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2fa0684276b6333ff3c0b1b27081f4b2305f0a36cf702a23db50edb141893c3f";
+    sha256 = "0ykr61yiiizgvm3bzipa3l73rvj49wmrybbfwhvpgk3pscl5pa68";
   };
 
   nativeBuildInputs = [ setuptools_scm ];

--- a/python/jupyter_c_kernel.nix
+++ b/python/jupyter_c_kernel.nix
@@ -4,6 +4,7 @@
 }:
 
 buildPythonPackage rec {
+  # https://pypi.org/project/jupyter_c_kernel/#history
   pname = "jupyter_c_kernel";
   version = "1.2.2";
   doCheck = false;

--- a/python/jupyter_contrib_core.nix
+++ b/python/jupyter_contrib_core.nix
@@ -6,6 +6,7 @@
 }:
 
 buildPythonPackage rec {
+  # https://pypi.org/project/jupyter_contrib_core/#history
   pname = "jupyter_contrib_core";
   version = "0.3.3";
   src = fetchPypi {

--- a/python/jupyter_nbextensions_configurator.nix
+++ b/python/jupyter_nbextensions_configurator.nix
@@ -5,6 +5,7 @@
 }:
 
 buildPythonPackage rec {
+  # https://pypi.org/project/jupyter_nbextensions_configurator/#history
   pname = "jupyter_nbextensions_configurator";
   version = "0.4.1";
   src = fetchPypi {

--- a/python/jupyterlab.nix
+++ b/python/jupyterlab.nix
@@ -10,12 +10,12 @@ buildPythonPackage rec {
   # https://jupyterlab.readthedocs.io/en/stable/getting_started/changelog.html
   # https://pypi.org/project/jupyterlab/#history
   pname = "jupyterlab";
-  version = "2.2.6";
+  version = "2.2.8";
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1zv3j8m8z8kycqy3n9cyz3khvmqicmy57v35w40024nds8ib0m35";
+    sha256 = "134b1i0hi0by62ajqqmyqksvffj46pzgjjcrwz0ijjah63p7ndy8";
   };
 
   propagatedBuildInputs = [ jupyterlab_server notebook ];

--- a/python/jupyterlab.nix
+++ b/python/jupyterlab.nix
@@ -7,13 +7,15 @@
 }:
 
 buildPythonPackage rec {
+  # https://jupyterlab.readthedocs.io/en/stable/getting_started/changelog.html
+  # https://pypi.org/project/jupyterlab/#history
   pname = "jupyterlab";
-  version = "1.2.3";
-  disabled = pythonOlder "3.5";
+  version = "2.2.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2188a9bcaaf0b6a68ff9098a481f37ece8231634b862fd3c9adedc466aac79f2";
+    sha256 = "1zv3j8m8z8kycqy3n9cyz3khvmqicmy57v35w40024nds8ib0m35";
   };
 
   propagatedBuildInputs = [ jupyterlab_server notebook ];

--- a/python/jupyterlab_server.nix
+++ b/python/jupyterlab_server.nix
@@ -10,13 +10,14 @@
 }:
 
 buildPythonPackage rec {
+  # https://pypi.org/project/jupyterlab-server/#history
   pname = "jupyterlab_server";
-  version = "1.0.6";
-  disabled = pythonOlder "3.5";
+  version = "1.2.0";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d0977527bfce6f47c782cb6bf79d2c949ebe3f22ac695fa000b730c671445dad";
+    sha256 = "132xby7531rbrjg9bqvsx86birr1blynjxy8gi5kcnb6x7fxjcal";
   };
 
   checkInputs = [ requests pytest ];

--- a/python/notebook.nix
+++ b/python/notebook.nix
@@ -24,13 +24,14 @@
 }:
 
 buildPythonPackage rec {
+  # https://pypi.org/project/notebook/#history
   pname = "notebook";
-  version = "6.0.1";
+  version = "6.0.3";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "660976fe4fe45c7aa55e04bf4bccb9f9566749ff637e9020af3422f9921f9a5d";
+    sha256 = "0j5d2zhhng7mg7a43lk0vc0x0dzn1h7s5f80v9d9dry9fllhkaa7";
   };
 
   LC_ALL = "en_US.utf8";

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -1,0 +1,43 @@
+# Test derivation for xc-jp/jupyterWith
+#
+# https://github.com/xc-jp/jupyterWith#getting-started
+#
+# Usage
+#
+#    nix-shell shell.nix -A env
+#    jupyter lab
+#
+
+{nixpkgs ? builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/2cd2e7267e5b9a960c2997756cb30e86f0958a6b.tar.gz";
+  sha256 = "0ir3rk776wldyjz6l6y5c5fs8lqk95gsik6w45wxgk6zdpsvhrn5";
+}}:
+
+let
+
+  haskell-nix = import (builtins.fetchTarball {
+    url = "https://github.com/input-output-hk/haskell.nix/archive/8fac80f3ea2e5195fcab9ad5c77d189cf6934b97.tar.gz";
+    sha256 = "1xii1k58bd4ywvc7kf91cipp5hm3ja53907baz7wz2x5k7hds2rf";
+  }) { };
+
+  jupyter-with = import ../.;
+
+  pkgs = import nixpkgs {
+    overlays = haskell-nix.nixpkgsArgs.overlays ++ jupyter-with.overlays;
+  };
+
+  iPython = pkgs.jupyterWith.kernels.iPythonWith {
+    name = "python";
+    packages = p: with p; [ ];
+  };
+
+  iHaskell = pkgs.jupyterWith.kernels.iHaskellWith {
+    name = "haskell";
+    packages = p: with p; [ hvega formatting ];
+  };
+
+  jupyterEnvironment = pkgs.jupyterWith.jupyterlabWith {
+    kernels = [ iPython iHaskell ];
+  };
+in
+  jupyterEnvironment


### PR DESCRIPTION
Upgrade to JupyterLab 2.2.8, which will one of the last JupyterLab 2 versions before version 3.
https://jupyterlab.readthedocs.io/en/stable/getting_started/changelog.html

Upgrade Stackage resolver to lts-14.27.

Backport Nix expression for installing JupyterLab extensions from local source tree https://github.com/tweag/jupyterWith/pull/116

Add a `test/shell.nix`.